### PR TITLE
Update __init__.py

### DIFF
--- a/gitpass/__init__.py
+++ b/gitpass/__init__.py
@@ -78,6 +78,7 @@ def save_password(passfile, password):
     Creates/overwrites a file 'passfile' to contain contents
     'password'
     """
+    password = password.encode("utf-8")
     with open(passfile, 'w') as f:
         f.write("%s\n" % (base64.b64encode(password),))
 


### PR DESCRIPTION
base64.b64encode requires a bytes-like object instead of str.
Throws a TypeError
By encoding the password to UTF-8 before the b64encode, this is fixed.